### PR TITLE
ci: pin changesets/action to v1.9.0 and fix publish input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,9 @@ jobs:
 
       - name: Create Release PR or publish to npm
         id: changesets
-        uses: changesets/action@v2
+        uses: changesets/action@v1.9.0
         with:
-          publish-script: yarn release
+          publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The release workflow was pinned to `changesets/action@v2`, but that ref does not resolve — `v2` exists only as pre-release tags (`v2.0.0-next.0` through `v2.0.0-next.3`) with no floating `v2` tag or branch on the action repo. It also passed `publish-script:`, which is the v2 input name (v1 uses `publish:`), so the two lines were inconsistent with each other regardless.

This pins to `changesets/action@v1.9.0` — the latest stable release, and the first major line that supports npm provenance / trusted publishing (added in v1.7.0) — and renames `publish-script` → `publish` to match the v1 input.

Everything else needed for provenance was already in place:

- `permissions: id-token: write` for OIDC
- `NPM_CONFIG_PROVENANCE: "true"` in the step env
- `registry-url: https://registry.npmjs.org` on `actions/setup-node`
- Node 24, which ships npm 11 (well above the npm 9.5.0 provenance floor)

## Test plan

- [ ] Merge a changeset PR and confirm the workflow resolves `changesets/action@v1.9.0` and runs `yarn release` without an "unresolved action" error
- [ ] Verify the published package on npm shows a provenance badge / attestation
