### PR TITLE
chore: sync issue and PR templates from allonsy-studio/.github

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Before opening a bug report, please search existing issues for this project to avoid duplicates.
+        Before opening a bug report, please search [existing issues](https://github.com/castastrophe/postcss-custom-prop-sorting/issues) to avoid duplicates.
 
   - type: textarea
     id: description
@@ -19,10 +19,17 @@ body:
     id: reproduction
     attributes:
       label: Steps to reproduce
-      description: The exact steps needed to trigger the bug.
+      description: |
+        The exact steps needed to trigger the bug. A minimal input snippet and the
+        plugin options you used are especially helpful.
       placeholder: |
-        1. Run `<command>` in a directory that contains...
-        2. Observe that...
+        1. Input CSS:
+           ```css
+           .foo { --b: 1; --a: var(--b); }
+           ```
+        2. Plugin options: `customPropSorting({ ... })`
+        3. Run: `postcss -u postcss-custom-prop-sorting -o out.css in.css`
+        4. Observe that...
     validations:
       required: true
 
@@ -42,13 +49,30 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: postcss-version
+    attributes:
+      label: PostCSS version
+      description: The version of `postcss` your project resolves (e.g. `8.5.6`). Check with `npm ls postcss` or `yarn why postcss`.
+      placeholder: 8.x.x
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: postcss-custom-prop-sorting version
+      description: The version of this plugin you're on.
+      placeholder: 2.x.x
+    validations:
+      required: true
+
   - type: textarea
     id: environment
     attributes:
       label: Environment
       description: Fill in the relevant details.
       value: |
-        - Affected project version:
         - Node.js version:
         - Package manager + version:
         - OS:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Something isn't working as expected
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a bug report, please search existing issues for this project to avoid duplicates.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear summary of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: The exact steps needed to trigger the bug.
+      placeholder: |
+        1. Run `<command>` in a directory that contains...
+        2. Observe that...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include any error output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Fill in the relevant details.
+      value: |
+        - Affected project version:
+        - Node.js version:
+        - Package manager + version:
+        - OS:
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help — screenshots, related issues, workarounds you've tried.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & discussion
+    url: https://github.com/orgs/Allons-y-Studio/discussions
+    about: Have a question or want to discuss an idea? Start a discussion instead of opening an issue.
+  - name: 🔐 Report a security vulnerability
+    url: https://github.com/Allons-y-Studio/.github/security/policy
+    about: Please report security issues privately — see our security policy.
+  - name: 🆘 Support
+    url: https://github.com/Allons-y-Studio/.github/blob/main/SUPPORT.md
+    about: Need help using one of our projects? Here's how to get support.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Questions & discussion
-    url: https://github.com/orgs/Allons-y-Studio/discussions
+    url: https://github.com/castastrophe/postcss-custom-prop-sorting/discussions
     about: Have a question or want to discuss an idea? Start a discussion instead of opening an issue.
   - name: 🔐 Report a security vulnerability
-    url: https://github.com/Allons-y-Studio/.github/security/policy
-    about: Please report security issues privately — see our security policy.
-  - name: 🆘 Support
-    url: https://github.com/Allons-y-Studio/.github/blob/main/SUPPORT.md
-    about: Need help using one of our projects? Here's how to get support.
+    url: https://github.com/castastrophe/postcss-custom-prop-sorting/security/policy
+    about: Please report security issues privately — see the repository's security policy.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,27 @@
+name: 📚 Documentation issue
+description: Report missing, unclear, or incorrect documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Where in the docs?
+      description: Link or path to the section with the problem (e.g. `README.md#inputs`).
+      placeholder: README.md#inputs
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing?
+      description: Describe what's unclear, inaccurate, or absent.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: Optional — propose specific wording or structure changes.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -7,8 +7,8 @@ body:
     id: location
     attributes:
       label: Where in the docs?
-      description: Link or path to the section with the problem (e.g. `README.md#inputs`).
-      placeholder: README.md#inputs
+      description: Link or path to the section with the problem (e.g. `README.md#options`).
+      placeholder: README.md#options
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: ✨ Feature request
+description: Suggest an idea or enhancement.
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea! Tell us about the problem you're trying to
+        solve — that helps us find the best solution together.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched [existing issues](https://github.com/Allons-y-Studio/.github/issues) and didn't find a duplicate.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: A clear description of the pain point or need. Focus on the "why".
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: What would the ideal outcome look like?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or other approaches you've thought about.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, links, or anything else that helps make the case.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Before you start
       options:
-        - label: I searched [existing issues](https://github.com/Allons-y-Studio/.github/issues) and didn't find a duplicate.
+        - label: I searched [existing issues](https://github.com/castastrophe/postcss-custom-prop-sorting/issues) and didn't find a duplicate.
           required: true
 
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+  Thanks for contributing to Allons-y Studio! 🎉
+  Please fill out the sections below. Keep PRs focused — smaller is easier to review.
+-->
+
+## What
+
+<!-- One-line summary of the change. -->
+
+## Why
+
+<!-- Motivation. Link any related issue (e.g. closes #123). For substantive changes, an issue is appreciated; small fixes can skip it. -->
+
+Closes #
+
+## How
+
+<!-- Implementation notes — especially anything non-obvious about the approach. -->
+
+## Test plan
+
+<!-- How you verified the change works. Paste relevant test output or describe the manual steps. -->
+
+## Checklist
+
+- [ ] My code follows the project's style and conventions.
+- [ ] I have performed a self-review of my changes.
+- [ ] I have added or updated tests where appropriate.
+- [ ] I have updated documentation where appropriate.
+- [ ] My changes generate no new warnings or accessibility regressions.
+- [ ] I have read the [Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,3 +29,4 @@ Closes #
 - [ ] I have updated documentation where appropriate (README, `index.d.ts`).
 - [ ] My changes generate no new PostCSS warnings.
 - [ ] If this is a user-facing change, I have added a changeset (`yarn changeset`).
+- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE_OF_CONDUCT.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-  Thanks for contributing to Allons-y Studio! 🎉
+  Thanks for contributing to postcss-custom-prop-sorting! 🎉
   Please fill out the sections below. Keep PRs focused — smaller is easier to review.
 -->
 
@@ -19,13 +19,13 @@ Closes #
 
 ## Test plan
 
-<!-- How you verified the change works. Paste relevant test output or describe the manual steps. -->
+<!-- How you verified the change works. Paste `yarn test` output or describe the manual steps. -->
 
 ## Checklist
 
-- [ ] My code follows the project's style and conventions.
+- [ ] My code follows the project's style and conventions (`yarn lint`).
 - [ ] I have performed a self-review of my changes.
-- [ ] I have added or updated tests where appropriate.
-- [ ] I have updated documentation where appropriate.
-- [ ] My changes generate no new warnings or accessibility regressions.
-- [ ] I have read the [Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).
+- [ ] I have added or updated tests where appropriate (`yarn test`).
+- [ ] I have updated documentation where appropriate (README, `index.d.ts`).
+- [ ] My changes generate no new PostCSS warnings.
+- [ ] If this is a user-facing change, I have added a changeset (`yarn changeset`).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at <consulting@allons-y.llc>. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at <report@allons-y.studio>. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at <consulting@allons-y.llc>. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to postcss-custom-prop-sorting
+
+First off — thank you! 🎉 _Allons-y_ means "let's go," and we're glad you're
+going there with us. This guide explains how to contribute to this project.
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by our
+[Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to
+uphold it. Please report unacceptable behavior to **report@allons-y.studio**.
+
+## Ways to contribute
+
+You don't have to write code to make a difference:
+
+- 🐛 **Report bugs** — open an issue with clear reproduction steps.
+- ✨ **Suggest features** — tell us about the problem you're trying to solve.
+- 📚 **Improve docs** — typos, clarifications, and examples are always welcome.
+- 🧪 **Triage issues** — reproduce reports, confirm bugs, suggest labels.
+- 💬 **Help others** — answer questions in Discussions.
+
+## Reporting bugs & requesting features
+
+Please use our [issue templates](https://github.com/castastrophe/postcss-custom-prop-sorting/issues/new/choose).
+Before opening a new issue, search existing ones to avoid duplicates.
+
+## Development workflow
+
+1. **Fork** the repository and clone your fork.
+2. **Install** dependencies with `yarn install`.
+3. **Create a branch** from `main` using a descriptive name:
+   - `fix/short-description` for bug fixes
+   - `feat/short-description` for features
+   - `docs/short-description` for documentation
+4. **Make your changes** in small, focused commits.
+5. **Test** your changes locally with `yarn test` and add tests where
+   appropriate. `yarn coverage` produces a coverage report.
+6. **Lint and format** with `yarn lint` (or `yarn format` to auto-fix)
+   before committing.
+7. **Add a changeset** for any user-facing change: `yarn changeset`.
+8. **Open a pull request** against `main` and fill out the PR template.
+
+### Commit messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```md
+type(scope): short summary
+
+[optional body]
+[optional footer]
+```
+
+Common types:
+
+| Type       | When to use                                 |
+| ---------- | ------------------------------------------- |
+| `feat`     | A new feature (triggers a minor release)    |
+| `fix`      | A bug fix (triggers a patch release)        |
+| `docs`     | Documentation changes only                  |
+| `test`     | Adding or updating tests                    |
+| `refactor` | Code restructuring without behaviour change |
+| `chore`    | Tooling, config, dependency updates         |
+
+A `BREAKING CHANGE:` footer or a `!` after the type (e.g. `feat!:`) triggers a major release.
+
+### Pull request guidelines
+
+- Keep PRs focused — one logical change per PR is easiest to review.
+- Reference the issue your PR addresses (`Closes #123`).
+- Make sure CI passes and there are no new PostCSS warnings.
+- Be responsive to review feedback — we aim to be too.
+
+## License
+
+Contributions are accepted under this project's [Apache 2.0 license](LICENSE).
+By submitting a contribution, you agree that it may be distributed under those
+terms.
+
+## Questions?
+
+Open a [discussion](https://github.com/castastrophe/postcss-custom-prop-sorting/discussions).
+Thanks again for contributing! 💜


### PR DESCRIPTION
## What

Bring GitHub issue forms and PR templates from `allonsy-studio/.github@main` into this repo.

## What

- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, adds contact links for discussion / security / support
- `.github/ISSUE_TEMPLATE/documentation.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`

## Test plan

- [ ] Open the "New issue" chooser on this repo and confirm the four templates show up (Bug report, Feature request, Documentation issue) with blank issues disabled and the three contact links present
- [ ] Open a draft PR and confirm the PR template body is pre-populated