### PR TITLE
chore(release): customize changesets PR title and thanks messaging

### DIFF
--- a/.changeset/changelog.js
+++ b/.changeset/changelog.js
@@ -1,0 +1,18 @@
+import defaultChangelogFunctions from "@changesets/changelog-github";
+
+const MAINTAINER = "castastrophe";
+const soloMaintainerThanks = new RegExp(
+  String.raw` Thanks \[@${MAINTAINER}\]\(https:\/\/[^)]+\/${MAINTAINER}\)!`,
+);
+
+export default {
+  getDependencyReleaseLine: defaultChangelogFunctions.getDependencyReleaseLine,
+  async getReleaseLine(changeset, type, options) {
+    const line = await defaultChangelogFunctions.getReleaseLine(
+      changeset,
+      type,
+      options,
+    );
+    return line.replace(soloMaintainerThanks, "");
+  },
+};

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "./changelog.js",
     { "repo": "castastrophe/postcss-custom-prop-sorting" }
   ],
   "commit": false,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         uses: changesets/action@v1.9.0
         with:
           publish: yarn release
+          title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Set the release PR title to `chore(release): version packages` so it
matches the repo's conventional-commit style, and wrap
`@changesets/changelog-github` with a small local module that strips
the "Thanks @castastrophe!" line when the maintainer is the sole
author being thanked. External contributor thanks (including cases
where a contributor is thanked alongside the maintainer) are preserved.